### PR TITLE
Fix anonymous field marking

### DIFF
--- a/processor.go
+++ b/processor.go
@@ -76,6 +76,7 @@ func walk(v reflect.Value, s reflect.StructField, p *Field) (field *Field, err e
 
 	if p == nil {
 		field.Path = "$"
+		field.Anonymous = true
 	} else {
 		field.Path = fmt.Sprintf("%s.%s", p.Path, s.Name)
 		field.Anonymous = s.Anonymous

--- a/processor_test.go
+++ b/processor_test.go
@@ -27,7 +27,7 @@ func TestWalk(t *testing.T) {
 		t.Fatalf("walking service: %s", err)
 	}
 
-	expected := &Field{Path: "$", Children: []*Field{
+	expected := &Field{Path: "$", Anonymous: true, Children: []*Field{
 		{Path: "$.Workers"},
 		{Path: "$.Dependency", Children: []*Field{
 			{Path: "$.Dependency.Foo"},
@@ -52,11 +52,15 @@ func testGraph(t *testing.T, actual, expected, parent *Field) {
 	}
 
 	if actual.Parent != parent {
-		t.Fatalf("invalud parent for path %s: wanted %p, got %p", actual.Path, parent, actual.Parent)
+		t.Fatalf("invalid parent for path %s: wanted %p, got %p", actual.Path, parent, actual.Parent)
 	}
 
 	if len(actual.Children) != len(expected.Children) {
 		t.Fatalf("invalid number of children for path %s: wanted %d, got %d", actual.Path, len(expected.Children), len(actual.Children))
+	}
+
+	if actual.Anonymous != expected.Anonymous {
+		t.Fatalf("invalid anonymous field for path %s: wanted %v, got %v", actual.Path, expected.Anonymous, actual.Anonymous)
 	}
 
 	for i := 0; i < len(actual.Children); i++ {


### PR DESCRIPTION
The anonymous status was previously detected using a function that has
been removed in favor of an attribute on the `Field` struct. When doing
that we forgot to account for the root field, which in turn prevented
anything else from being configured.

This fix the attribute setting and add a relevant test to detect this.