### PR TITLE
Add example tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.2 - 2019-09-05
+### Added
+- Add a new tag called `example`
+
 ## 1.1.1 - 2019-06-25
 ### Changed
 - Remove the internal state of the `EnvProvider`

--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ needed to configure and initialize an application's dependencies.
 
 _zconfig_ primary feature is an extensible configuration repository. To use it,
 simply define a configuration structure and feed it to the `Configure()`
-method. You can use the `key`, `description` and `default` tags to define which
+method. You can use the `key`, `description`, `default` and `example` tags to define which
 key to use.
 
 ```go
 type Configuration struct {
 	Addr string `key:"addr" description:"address the server should bind to" default:":80"`
+	Name string `key:"name" description:"name displayed to the client" example:"zconfig"`
 }
 
 func main() {
@@ -32,12 +33,13 @@ func main() {
 
 Once compiled, the special flag `help` can be passed to the binary to display a
 list of the available configuration keys, in their cli and env form, as well as
-their description and default values.
+their description and default/example values.
 
 ```shell
 $ ./a.out --help
 Keys:
 addr	ADDR	address the server should bind to	(:80)
+name	NAME	name displayed to the client	example: zconfig
 ```
 
 Configurations can be nested into structs to improve usability, and the keys of
@@ -72,16 +74,15 @@ server.addr	SERVER_ADDR	address the server should bind to	(:80)
 
 The following types are handled by default by the library:
 
-* `encoding.TextUnmarshaller`
-* `encoding.BinaryUnmarshaller`
-* `(u)?int(32|64)?`
-* `float(32|64)`
-* `string`
-* `[]string`
-* `bool`
-* `time.Duration`
-* `regexp.Regexp`
-
+- `encoding.TextUnmarshaller`
+- `encoding.BinaryUnmarshaller`
+- `(u)?int(32|64)?`
+- `float(32|64)`
+- `string`
+- `[]string`
+- `bool`
+- `time.Duration`
+- `regexp.Regexp`
 
 ### Initialization
 
@@ -188,7 +189,7 @@ The `Field` struct is a graph representation of a single field of your
 configuration struct, with pointers for parent and children. The list of fields
 handled by the processor is ordered by deepest dependency first, meaning that
 for any given hook, all children of a given field are processed by the hook
-before the field itself.  For the case of injection, the targets aren't
+before the field itself. For the case of injection, the targets aren't
 included in this list, but the sources are processed before the target's
 branch.
 

--- a/field.go
+++ b/field.go
@@ -11,6 +11,7 @@ const (
 	TagKey         = "key"
 	TagDefault     = "default"
 	TagDescription = "description"
+	TagExample     = "example"
 )
 
 type Field struct {

--- a/processor.go
+++ b/processor.go
@@ -319,6 +319,8 @@ func usage(fields []*Field) {
 		desc, _ := field.Tags.Lookup(TagDescription)
 		if ok {
 			fmt.Fprintf(w, "%s\t%s\t%s\t(%s)\n", key, Env.FormatKey(key), desc, def)
+		} else if ex, ok := field.Tags.Lookup(TagExample); ok {
+			fmt.Fprintf(w, "%s\t%s\t%s\texample: %s\n", key, Env.FormatKey(key), desc, ex)
 		} else {
 			fmt.Fprintf(w, "%s\t%s\t%s\t\n", key, Env.FormatKey(key), desc)
 		}


### PR DESCRIPTION
This tag allow specification of example value instead of setting default
value as an example.
The example is only displayed when there is no default value (as it can be used as an example).
This only impact the processor.