### PR TITLE
Allow overriding the usage message

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,13 @@ hooks: the first is the one that do the actual configuration of the fields, and
 the second do the initialization of the field. The global `Configure()` and
 `AddHooks()` methods are shortcuts to the methods of this default processor.
 
+### Help Messages
+
+Help message is handled by the stock processor. After analyzing the given
+struct, it looks for a `--help` flag in the stock `ArgsProvider`. If found, it
+call the `zconfig.Processor.Usage` field (or the `zconfig.DefaultUsage` method
+if nil) to display help.
+
 ### Hook
 
 The `Hook` is a type for a function that takes a single pointer to a `Field` as

--- a/processor.go
+++ b/processor.go
@@ -16,6 +16,8 @@ import (
 type Processor struct {
 	lock  sync.Mutex
 	hooks []Hook
+
+	Usage func([]*Field)
 }
 
 func NewProcessor(hooks ...Hook) *Processor {
@@ -48,6 +50,11 @@ func (p *Processor) Process(s interface{}) error {
 	mark(root, "")
 
 	if _, ok, _ := Args.Retrieve("help"); ok {
+		usage := p.Usage
+		if p.Usage == nil {
+			usage = DefaultUsage
+		}
+
 		usage(fields)
 		os.Exit(0)
 	}
@@ -298,7 +305,7 @@ func mark(f *Field, key string) bool {
 	return true
 }
 
-func usage(fields []*Field) {
+func DefaultUsage(fields []*Field) {
 	var keys []string
 	var options = make(map[string]*Field)
 	for _, f := range fields {


### PR DESCRIPTION
The default processor now has a field Usage that allows users to
override the usage message. If non-nil when processing a struct and
finding the help message, it will be used in place of the DefaultUsage
method (the previous usage method now exported).