### PR TITLE
Split required & optional params in usage (--help)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.4.0 - 2021-02-22
+### Changed
+- Separate required and optional params in default usage (`--help`)
+
 ## 1.3.0 - 2020-04-16
 ### Added
 - Allow parsing slice of int and int64 values.

--- a/processor.go
+++ b/processor.go
@@ -319,18 +319,24 @@ func DefaultUsage(fields []*Field) {
 	}
 	sort.Strings(keys)
 
-	fmt.Printf("\nKeys:\n")
-	w := tabwriter.NewWriter(os.Stdout, 2, 2, 2, ' ', 0)
+	required := tabwriter.NewWriter(os.Stdout, 2, 2, 2, ' ', 0)
+	optional := tabwriter.NewWriter(os.Stdout, 2, 2, 2, ' ', 0)
+
 	for _, key := range keys {
 		field := options[key]
 
 		def, ok := field.Tags.Lookup(TagDefault)
 		desc, _ := field.Tags.Lookup(TagDescription)
 		if ok {
-			fmt.Fprintf(w, "%s\t%s\t%s\t(%s)\n", key, Env.FormatKey(key), desc, def)
+			fmt.Fprintf(optional, "%s\t%s\t%s\t(%s)\n", key, Env.FormatKey(key), desc, def)
 		} else {
-			fmt.Fprintf(w, "%s\t%s\t%s\t\n", key, Env.FormatKey(key), desc)
+			fmt.Fprintf(required, "%s\t%s\t%s\n", key, Env.FormatKey(key), desc)
 		}
 	}
-	_ = w.Flush()
+
+	fmt.Printf("\nRequired parameters:\n")
+	_ = required.Flush()
+
+	fmt.Printf("\nOptional parameters:\n")
+	_ = optional.Flush()
 }


### PR DESCRIPTION
When there are many configurable keys, it's hard to see which are "required" (= have no default value) and which are "optional" (= have a default value) since they're together in the same (long) list.

This splits the list in two, first the "required" parameters and then the "optional" parameters.