### PR TITLE
Add an new Init interface which takes a context as parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/synthesio/zconfig
+module github.com/synthesio/zconfig/v2
 
 go 1.12

--- a/init.go
+++ b/init.go
@@ -10,19 +10,36 @@ type Initializable interface {
 	Init(context.Context) error
 }
 
+type initializableDeprecated interface {
+	Init() error
+}
+
 // Used for type comparison.
 var typeInitializable = reflect.TypeOf((*Initializable)(nil)).Elem()
+var typeInitializableDeprecated = reflect.TypeOf((*initializableDeprecated)(nil)).Elem()
 
 func Initialize(ctx context.Context, field *Field) error {
 	// Not initializable, nothing to do.
-	if !field.Value.Type().Implements(typeInitializable) {
+	if field.Value.Type().Implements(typeInitializable) {
+
+		// Initialize the element itself via the interface.
+		err := field.Value.Interface().(Initializable).Init(ctx)
+		if err != nil {
+			return fmt.Errorf("initializing field: %s", err)
+		}
+
 		return nil
 	}
 
-	// Initialize the element itself via the interface.
-	err := field.Value.Interface().(Initializable).Init(ctx)
-	if err != nil {
-		return fmt.Errorf("initializing field: %s", err)
+	if field.Value.Type().Implements(typeInitializableDeprecated) {
+
+		// Initialize the element itself via the interface.
+		err := field.Value.Interface().(initializableDeprecated).Init()
+		if err != nil {
+			return fmt.Errorf("initializing field: %s", err)
+		}
+
+		return nil
 	}
 
 	return nil

--- a/init.go
+++ b/init.go
@@ -7,41 +7,20 @@ import (
 )
 
 type Initializable interface {
-	Init() error
-}
-
-type InitializableEx interface {
 	Init(context.Context) error
 }
 
 // Used for type comparison.
 var typeInitializable = reflect.TypeOf((*Initializable)(nil)).Elem()
-var typeInitializableEx = reflect.TypeOf((*InitializableEx)(nil)).Elem()
 
-// DEPRECATED
-func Initialize(field *Field) error {
+func Initialize(ctx context.Context, field *Field) error {
 	// Not initializable, nothing to do.
 	if !field.Value.Type().Implements(typeInitializable) {
 		return nil
 	}
 
 	// Initialize the element itself via the interface.
-	err := field.Value.Interface().(Initializable).Init()
-	if err != nil {
-		return fmt.Errorf("initializing field: %s", err)
-	}
-
-	return nil
-}
-
-func InitializeEx(ctx context.Context, field *Field) error {
-	var err error
-	if field.Value.Type().Implements(typeInitializableEx) {
-		err = field.Value.Interface().(InitializableEx).Init(ctx)
-	} else if field.Value.Type().Implements(typeInitializable) {
-		// Initialize the element itself via the interface.
-		err = field.Value.Interface().(Initializable).Init()
-	}
+	err := field.Value.Interface().(Initializable).Init(ctx)
 	if err != nil {
 		return fmt.Errorf("initializing field: %s", err)
 	}

--- a/init_test.go
+++ b/init_test.go
@@ -1,19 +1,22 @@
 package zconfig
 
-import "testing"
+import (
+	"context"
+	"testing"
+)
 
 type initTest struct {
 	Initialized bool
 }
 
-func (i *initTest) Init() error {
+func (i *initTest) Init(ctx context.Context) error {
 	i.Initialized = true
 	return nil
 }
 
 func TestInitialize(t *testing.T) {
 	initMe := new(initTest)
-	err := NewProcessor(Initialize).Process(initMe)
+	err := NewProcessor(Initialize).Process(context.Background(), initMe)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/init_test.go
+++ b/init_test.go
@@ -14,14 +14,36 @@ func (i *initTest) Init(ctx context.Context) error {
 	return nil
 }
 
-func TestInitialize(t *testing.T) {
-	initMe := new(initTest)
-	err := NewProcessor(Initialize).Process(context.Background(), initMe)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
+type initTestDeprecated struct {
+	init initTest
+}
 
-	if !initMe.Initialized {
-		t.Fatal("struct was not initialized as expected")
-	}
+func (i *initTestDeprecated) Init() error {
+	return i.init.Init(context.Background())
+}
+
+func TestInitialize(t *testing.T) {
+	t.Run("with context", func(t *testing.T) {
+		initMe := new(initTest)
+		err := NewProcessor(Initialize).Process(context.Background(), initMe)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !initMe.Initialized {
+			t.Fatal("struct was not initialized as expected")
+		}
+	})
+
+	t.Run("without context", func(t *testing.T) {
+		initMe := new(initTestDeprecated)
+		err := NewProcessor(Initialize).Process(context.Background(), initMe)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if !initMe.init.Initialized {
+			t.Fatal("struct was not initialized as expected")
+		}
+	})
 }

--- a/processor.go
+++ b/processor.go
@@ -1,6 +1,7 @@
 package zconfig
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"reflect"
@@ -14,8 +15,9 @@ import (
 // A Processor handle the service processing and execute hooks on the resulting
 // fields.
 type Processor struct {
-	lock  sync.Mutex
-	hooks []Hook
+	lock    sync.Mutex
+	hooks   []Hook
+	hooksEx []HookEx
 
 	// Usage message to be displayed on error or when help is requested.
 	// DefaultUsage will be used if left nil.
@@ -28,7 +30,26 @@ func NewProcessor(hooks ...Hook) *Processor {
 	}
 }
 
+func (p *Processor) getHooks(ctx context.Context) []Hook {
+	ret := make([]Hook, 0, len(p.hooks)+len(p.hooksEx))
+	for i := range p.hooksEx {
+		ret = append(ret, func(field *Field) error {
+			return p.hooksEx[i](ctx, field)
+		})
+	}
+	ret = append(ret, p.hooks...)
+	return ret
+}
+
 func (p *Processor) Process(s interface{}) error {
+	return p.process(func() []Hook { return p.hooks }, s)
+}
+
+func (p *Processor) ProcessEx(ctx context.Context, s interface{}) error {
+	return p.process(func() []Hook { return p.getHooks(ctx) }, s)
+}
+
+func (p *Processor) process(getHooks func() []Hook, s interface{}) error {
 	v := reflect.ValueOf(s)
 
 	if v.Kind() != reflect.Ptr {
@@ -61,7 +82,7 @@ func (p *Processor) Process(s interface{}) error {
 		os.Exit(0)
 	}
 
-	for _, hook := range p.hooks {
+	for _, hook := range getHooks() {
 		for _, field := range fields {
 			err := hook(field)
 			if err != nil {
@@ -75,6 +96,10 @@ func (p *Processor) Process(s interface{}) error {
 
 func (p *Processor) AddHooks(hooks ...Hook) {
 	p.hooks = append(p.hooks, hooks...)
+}
+
+func (p *Processor) AddHooksEx(hooks ...HookEx) {
+	p.hooksEx = append(p.hooksEx, hooks...)
 }
 
 func walk(v reflect.Value, s reflect.StructField, p *Field) (field *Field, err error) {

--- a/processor_test.go
+++ b/processor_test.go
@@ -1,6 +1,7 @@
 package zconfig
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"strings"
@@ -206,12 +207,12 @@ func TestProcessorHooks(t *testing.T) {
 	t.Run("execution", func(t *testing.T) {
 		executed := false
 
-		testHook := func(field *Field) error {
+		testHook := func(ctx context.Context, field *Field) error {
 			executed = true
 			return nil
 		}
 
-		err := NewProcessor(testHook).Process(new(Service))
+		err := NewProcessor(testHook).Process(context.Background(), new(Service))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -230,7 +231,7 @@ func TestProcessorHooks(t *testing.T) {
 			"$.Recursive":      false,
 		}
 
-		testHook := func(field *Field) error {
+		testHook := func(ctx context.Context, field *Field) error {
 			visited, ok := fields[field.Path]
 			if !ok {
 				t.Fatalf("unexpected field: %s", field.Path)
@@ -244,18 +245,18 @@ func TestProcessorHooks(t *testing.T) {
 			return nil
 		}
 
-		err := NewProcessor(testHook).Process(new(Service))
+		err := NewProcessor(testHook).Process(context.Background(), new(Service))
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
 	t.Run("error", func(t *testing.T) {
-		testHook := func(field *Field) error {
+		testHook := func(ctx context.Context, field *Field) error {
 			return errors.New("an error")
 		}
 
-		err := NewProcessor(testHook).Process(new(Service))
+		err := NewProcessor(testHook).Process(context.Background(), new(Service))
 		if err == nil {
 			t.Fatalf("expected an error, got nil")
 		}

--- a/repository.go
+++ b/repository.go
@@ -1,6 +1,7 @@
 package zconfig
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"reflect"
@@ -67,7 +68,7 @@ func (r *Repository) Parse(raw, res interface{}) (err error) {
 	return fmt.Errorf("no parser for type %T", res)
 }
 
-func (r *Repository) Hook(f *Field) (err error) {
+func (r *Repository) Hook(ctx context.Context, f *Field) (err error) {
 	if !f.Configurable {
 		return nil
 	}

--- a/zconfig.go
+++ b/zconfig.go
@@ -15,27 +15,20 @@ func init() {
 	DefaultRepository.AddProviders(Args, Env)
 	DefaultRepository.AddParsers(ParseString)
 	DefaultProcessor.AddHooks(DefaultRepository.Hook, Initialize)
-	DefaultProcessor.AddHooksEx(InitializeEx)
 }
 
 // Configure a service using the default processor.
-func Configure(s interface{}) error {
-	return DefaultProcessor.Process(s)
+func Configure(ctx context.Context, s interface{}) error {
+	return DefaultProcessor.Process(ctx, s)
 }
 
 // A Hook can be used to act upon every field visited by the repository when
 // configuring a service.
-type Hook func(field *Field) error
-
-type HookEx func(context.Context, *Field) error
+type Hook func(ctx context.Context, field *Field) error
 
 // Add a hook to the default repository.
 func AddHooks(hooks ...Hook) {
 	DefaultProcessor.AddHooks(hooks...)
-}
-
-func AddHooksEx(hooksEx ...HookEx) {
-	DefaultProcessor.AddHooksEx(hooksEx...)
 }
 
 // Provider is the interface implemented by all entity a configuration key can

--- a/zconfig.go
+++ b/zconfig.go
@@ -1,5 +1,9 @@
 package zconfig
 
+import (
+	"context"
+)
+
 var (
 	DefaultRepository Repository
 	DefaultProcessor  Processor
@@ -11,6 +15,7 @@ func init() {
 	DefaultRepository.AddProviders(Args, Env)
 	DefaultRepository.AddParsers(ParseString)
 	DefaultProcessor.AddHooks(DefaultRepository.Hook, Initialize)
+	DefaultProcessor.AddHooksEx(InitializeEx)
 }
 
 // Configure a service using the default processor.
@@ -22,9 +27,15 @@ func Configure(s interface{}) error {
 // configuring a service.
 type Hook func(field *Field) error
 
+type HookEx func(context.Context, *Field) error
+
 // Add a hook to the default repository.
 func AddHooks(hooks ...Hook) {
 	DefaultProcessor.AddHooks(hooks...)
+}
+
+func AddHooksEx(hooksEx ...HookEx) {
+	DefaultProcessor.AddHooksEx(hooksEx...)
 }
 
 // Provider is the interface implemented by all entity a configuration key can

--- a/zconfig_test.go
+++ b/zconfig_test.go
@@ -1,6 +1,7 @@
 package zconfig
 
 import (
+	"context"
 	"testing"
 	"time"
 )
@@ -52,7 +53,7 @@ type Tester struct {
 	t *testing.T
 }
 
-func (tester *Tester) Hook(field *Field) error {
+func (tester *Tester) Hook(ctx context.Context, field *Field) error {
 	expectedProviders := map[string]string{
 		"foo": "test",
 		"baz": "test2",
@@ -93,7 +94,7 @@ func TestConfigure(t *testing.T) {
 	AddHooks(tester.Hook)
 	AddProviders(p, p2)
 	var s S
-	err := Configure(&s)
+	err := Configure(context.Background(), &s)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
A context give as parameter of the `Init` method of the initializable object will allow to perform I/O blocking which could then be cancelled through its context if needed.