### PR TITLE
Add CustomParser interface to allow custom type to be use in ParseString

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0 - 2022-05-25
+### Changed
+- update go.mod to go 1.18
+- add a new interface `CustomParser` to allow custom type to be used in `ParseString`
+
 ## 2.0.1 - 2022-05-12
 ### Fixed
 - make sure to wrap errors when using fmt.Errorf

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/synthesio/zconfig/v2
 
-go 1.12
+go 1.18

--- a/parser.go
+++ b/parser.go
@@ -8,6 +8,10 @@ import (
 	"time"
 )
 
+type CustomParser interface {
+	Parse(string) error
+}
+
 func ParseString(raw, res interface{}) (err error) {
 	s, ok := raw.(string)
 	if !ok {
@@ -123,6 +127,12 @@ func ParseString(raw, res interface{}) (err error) {
 		}
 		*res = v
 	default:
+		if v, ok := res.(CustomParser); ok {
+			err := v.Parse(s)
+			if err == nil {
+				return nil
+			}
+		}
 		return ErrNotParseable
 	}
 


### PR DESCRIPTION
Adding a CustomParser allow a client to implement the interface to use custom type
for example a typed string.

ParseString is able to check if the res variable implement the CustomParser interface then call it.
It returns an error if the method Parse is failing.
If the res variable do not implement the CustomParser interface the normal behavior will returns an error.