### PR TITLE
Make injection work on non pointer target fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 3.0.0 - 2022-09-12
+### Changed
+- Handle injection via a dedicated `Inject` hook executed just after `Repository.Hook`
+  to have proper injection of non-pointer fields.
+  This is considered a breaking change because injection was previously 
+  handled by the call to `Processor.Process` independently of any registered Hooks.
+  **Important:** Users who do not call the `Configure` and do not use the `DefaultProcessor` must
+  add the `Inject` hook to their `Processor`, otherwise injection will stop working.
+
 ## 2.0.1 - 2022-05-12
 ### Fixed
-- make sure to wrap errors when using fmt.Errorf
-- error returned by hooks such as Init can be unwrapped
+- Make sure to wrap errors when using fmt.Errorf
+- Error returned by hooks such as Init can be unwrapped
 
 ## 2.0.0 - 2022-04-29
 ### Added
-- new Init interface which takes a context as parameter
+- New Init interface which takes a context as parameter
 
 ## 1.4.1 - 2021-12-15
 ### Fixed

--- a/field.go
+++ b/field.go
@@ -26,18 +26,26 @@ type Field struct {
 	Provider         string
 	Configurable     bool
 	ConfigurationKey string
+
+	// InjectionTargets contains a list of values registered for the injection
+	// of this field value, once it has been set.
+	InjectionTargets []reflect.Value
 }
 
-func (f *Field) Inject(s *Field) (err error) {
-	if !s.Value.Type().AssignableTo(f.Value.Type()) {
-		return fmt.Errorf("cannot inject %s into %s for field %s", s.Value.Type(), f.Value.Type(), f.Path)
+// AddInjectionTarget registers the value of the given target field for injection.
+// The method returns an error if the target type is not compatible with the receiver field type or
+// if the target value cannot be addressed.
+func (f *Field) AddInjectionTarget(target *Field) (err error) {
+	if !f.Value.Type().AssignableTo(target.Value.Type()) {
+		return fmt.Errorf("cannot inject %s into %s for field %s", f.Value.Type(), target.Value.Type(), target.Path)
 	}
 
-	if !f.Value.CanSet() {
-		return fmt.Errorf("cannot address %s for injection", f.Value.Type())
+	if !target.Value.CanSet() {
+		return fmt.Errorf("cannot address %s for injection", target.Value.Type())
 	}
 
-	f.Value.Set(s.Value)
+	f.InjectionTargets = append(f.InjectionTargets, target.Value)
+
 	return nil
 }
 

--- a/field_test.go
+++ b/field_test.go
@@ -5,32 +5,90 @@ import (
 	"testing"
 )
 
-type InjectionDependency struct {
+type injectionDependency struct {
 	F string
 }
 
-type InjectionService struct {
-	Source *InjectionDependency `inject-as:"source"`
-	Target *InjectionDependency `inject:"source"`
+func (injectionDependency) do() {}
+
+type doer interface {
+	do()
 }
 
-func TestField_Inject(t *testing.T) {
-	var s InjectionService
-	root, err := walk(reflect.ValueOf(&s), reflect.StructField{}, nil)
-	if err != nil {
-		t.Fatalf("walking service: %s", err)
+func TestField_AddInjectionTarget(t *testing.T) {
+	// nominal cases
+	for name, tCase := range map[string]reflect.Value{
+		"struct pointer": reflect.ValueOf(new(struct {
+			Source *injectionDependency `inject-as:"source"`
+			Target *injectionDependency `inject:"source"`
+		})),
+		"scalar pointer": reflect.ValueOf(new(struct {
+			Source *int `inject-as:"source"`
+			Target *int `inject:"source"`
+		})),
+		"scalar value": reflect.ValueOf(new(struct {
+			Source string `inject-as:"source"`
+			Target string `inject:"source"`
+		})),
+		"interface": reflect.ValueOf(new(struct {
+			Source injectionDependency `inject-as:"source"`
+			Target doer                `inject:"source"`
+		})),
+	} {
+		t.Run(name, func(t *testing.T) {
+			root, err := walk(tCase, reflect.StructField{}, nil)
+			if err != nil {
+				t.Fatalf("walking service: %s", err)
+			}
+
+			if len(root.Children) != 2 {
+				t.Fatalf("unexpected number of children: wanted %d, got %d", 2, len(root.Children))
+			}
+
+			err = root.Children[0].AddInjectionTarget(root.Children[1])
+			if err != nil {
+				t.Fatalf("unable to inject source into target: %s", err)
+			}
+
+			if len(root.Children[0].InjectionTargets) != 1 {
+				t.Fatalf("unexpected number of injection targets: %d", len(root.Children[0].InjectionTargets))
+			}
+
+			if root.Children[0].InjectionTargets[0] != root.Children[1].Value {
+				t.Fatalf("unexpected registered target value")
+			}
+		})
 	}
 
-	if len(root.Children) != 2 {
-		t.Fatalf("unexpected number of children: wanted %d, got %d", 2, len(root.Children))
-	}
+	// errors
+	for name, tCase := range map[string]reflect.Value{
+		"pointer into value": reflect.ValueOf(new(struct {
+			Source *injectionDependency `inject-as:"source"`
+			Target injectionDependency  `inject:"source"`
+		})),
+		"value into pointer": reflect.ValueOf(new(struct {
+			Source int  `inject-as:"source"`
+			Target *int `inject:"source"`
+		})),
+		"type mismatch": reflect.ValueOf(new(struct {
+			Source int    `inject-as:"source"`
+			Target string `inject:"source"`
+		})),
+	} {
+		t.Run(name, func(t *testing.T) {
+			root, err := walk(tCase, reflect.StructField{}, nil)
+			if err != nil {
+				t.Fatalf("walking service: %s", err)
+			}
 
-	err = root.Children[1].Inject(root.Children[0])
-	if err != nil {
-		t.Fatalf("unable to inject source into target: %s", err)
-	}
+			if len(root.Children) != 2 {
+				t.Fatalf("unexpected number of children: wanted %d, got %d", 2, len(root.Children))
+			}
 
-	if s.Source != s.Target {
-		t.Fatalf("failed injection")
+			err = root.Children[0].AddInjectionTarget(root.Children[1])
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/synthesio/zconfig/v2
+module github.com/synthesio/zconfig/v3
 
 go 1.12

--- a/inject.go
+++ b/inject.go
@@ -1,0 +1,20 @@
+package zconfig
+
+import (
+	"context"
+)
+
+// Inject is a Hook responsible for injecting source values into their targets.
+// It must always be executed after any Repository hooks to ensure that
+// source field values have already been populated.
+func Inject(ctx context.Context, f *Field) error {
+	if len(f.InjectionTargets) == 0 {
+		return nil
+	}
+
+	for _, target := range f.InjectionTargets {
+		target.Set(f.Value)
+	}
+
+	return nil
+}

--- a/inject_test.go
+++ b/inject_test.go
@@ -1,0 +1,77 @@
+package zconfig
+
+import (
+	"context"
+	"testing"
+)
+
+type injectionMock struct {
+	called bool
+}
+
+func (n *injectionMock) call() {
+	n.called = true
+}
+
+type caller interface {
+	call()
+}
+
+func TestInject(t *testing.T) {
+	t.Run("pointers", func(t *testing.T) {
+		var s struct {
+			Source *string `inject-as:"source"`
+			Target *string `inject:"source"`
+		}
+		err := NewProcessor(Inject).Process(context.Background(), &s)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if s.Source != s.Target {
+			t.Fatal("target was not injected with source")
+		}
+	})
+
+	t.Run("values", func(t *testing.T) {
+		const helloWorld = "hello, world"
+
+		var s struct {
+			Source string `inject-as:"source"`
+			Target string `inject:"source"`
+		}
+		s.Source = helloWorld
+
+		err := NewProcessor(Inject).Process(context.Background(), &s)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if s.Target != helloWorld {
+			t.Fatal("target was not injected with source")
+		}
+	})
+
+	t.Run("interface", func(t *testing.T) {
+		var s struct {
+			Source *injectionMock `inject-as:"source"`
+			Target caller         `inject:"source"`
+		}
+		err := NewProcessor(Inject).Process(context.Background(), &s)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		if s.Target == nil {
+			t.Fatal("source was not injected into target")
+		}
+
+		if s.Source.called {
+			t.Fatal("unexepected starting value for source.called field")
+		}
+		s.Target.call()
+		if !s.Source.called {
+			t.Fatal("method was not called on source")
+		}
+	})
+}

--- a/processor.go
+++ b/processor.go
@@ -205,7 +205,7 @@ func resolve(root *Field) (fields []*Field, err error) {
 		dependencies.add(e, e.Children...)
 	}
 
-	// Inject the sources into the targets and add them to the dependencies
+	// Register injection targets into sources and mark sources as dependencies
 	// of the targets.
 	for target, key := range targets {
 		source, ok := sources[key]
@@ -213,9 +213,9 @@ func resolve(root *Field) (fields []*Field, err error) {
 			return nil, fmt.Errorf("injection source key %s undefined for path %s", key, target.Path)
 		}
 
-		err := target.Inject(source)
+		err := source.AddInjectionTarget(target)
 		if err != nil {
-			return nil, fmt.Errorf("injecting field %s into %s: %w", source.Path, target.Path, err)
+			return nil, fmt.Errorf("adding injection target %s to %s: %w", target.Path, source.Path, err)
 		}
 
 		dependencies.add(target, source)

--- a/repository.go
+++ b/repository.go
@@ -18,7 +18,7 @@ type Repository struct {
 	parsers   []Parser
 }
 
-// Register a new Provider in this repository.
+// AddProviders registers a new Provider in this repository.
 func (r *Repository) AddProviders(providers ...Provider) {
 	r.lock.Lock()
 	defer r.lock.Unlock()
@@ -45,7 +45,7 @@ func (r *Repository) Retrieve(key string) (value interface{}, provider string, f
 
 var ErrNotParseable = errors.New("not parseable")
 
-// Register allow anyone to add a custom parser to the list.
+// AddParsers allows anyone to add a custom parser to the list.
 func (r *Repository) AddParsers(parsers ...Parser) {
 	r.lock.Lock()
 	defer r.lock.Unlock()

--- a/zconfig.go
+++ b/zconfig.go
@@ -14,7 +14,7 @@ var (
 func init() {
 	DefaultRepository.AddProviders(Args, Env)
 	DefaultRepository.AddParsers(ParseString)
-	DefaultProcessor.AddHooks(DefaultRepository.Hook, Initialize)
+	DefaultProcessor.AddHooks(DefaultRepository.Hook, Inject, Initialize)
 }
 
 // Configure a service using the default processor.
@@ -26,7 +26,7 @@ func Configure(ctx context.Context, s interface{}) error {
 // configuring a service.
 type Hook func(ctx context.Context, field *Field) error
 
-// Add a hook to the default repository.
+// AddHooks Adds the given hooks to the default repository.
 func AddHooks(hooks ...Hook) {
 	DefaultProcessor.AddHooks(hooks...)
 }
@@ -39,7 +39,7 @@ type Provider interface {
 	Priority() int
 }
 
-// Add a provider to the default repository.
+// AddProviders Adds the given providers to the default repository.
 func AddProviders(providers ...Provider) {
 	DefaultRepository.AddProviders(providers...)
 }
@@ -48,7 +48,7 @@ func AddProviders(providers ...Provider) {
 // given type.
 type Parser func(interface{}, interface{}) error
 
-// Add a parser to the default repository.
+// AddParsers Adds the given parsers to the default repository.
 func AddParsers(parsers ...Parser) {
 	DefaultRepository.AddParsers(parsers...)
 }

--- a/zconfig_test.go
+++ b/zconfig_test.go
@@ -86,16 +86,19 @@ func TestConfigure(t *testing.T) {
 		"a.b.c.d": "6",
 		"m.foo":   "7",
 	}}
-	var p2 = TestProvider{
-		"test2",
-		map[string]string{
-			"baz": "baz",
-		}}
+	var p2 = TestProvider{"test2", map[string]string{
+		"baz": "baz",
+	}}
 	AddHooks(tester.Hook)
 	AddProviders(p, p2)
 	var s S
 	err := Configure(context.Background(), &s)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	// check that injection worked
+	if s.L != s.A {
+		t.Fatalf("injection of 'a' wasn't successful")
 	}
 }


### PR DESCRIPTION
Handle injection via a dedicated `Inject` hook executed just after `Repository.Hook` to have proper injection of non-pointer fields.

This is considered a breaking change because injection was previously handled by the call to `Processor.Process` independently of any registered Hooks.

**Important:** Users who do not call the `Configure` and do not use the `DefaultProcessor` must add the `Inject` hook to their `Processor`, otherwise injection will stop working.