### PR TITLE
Raise an error when detecting injections defined on non pointer sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.1.0 - 2022-09-12
+### Changed
+- `Processor.Process` will now return an error when a non pointer type is used as an injection source 
+
 ## 2.0.1 - 2022-05-12
 ### Fixed
 - make sure to wrap errors when using fmt.Errorf

--- a/README.md
+++ b/README.md
@@ -160,17 +160,17 @@ into another, thus sharing resources. The `inject-as` tag defines an _injection
 source_ and the key used to identify it, while the `inject` tag defines an
 _injection target_ and the key of the source to use.
 
-Any type can be injected as long as the source is _assignable_ to the target.
+Any pointer type can be injected as long as the source is _assignable_ to the target.
 This is especially useful to allow sharing common configuration fields or even
 whole structs like a database handle.
 
 ```go
 type Service struct {
 	Foo struct{
-		Root string `inject:"bar-root"`
+		Root *string `inject:"bar-root"`
 	}
 	Bar struct{
-		Root string `inject-as:"bar-root"`
+		Root *string `inject-as:"bar-root"`
 	}
 }
 ```

--- a/field_test.go
+++ b/field_test.go
@@ -9,28 +9,125 @@ type InjectionDependency struct {
 	F string
 }
 
+func (InjectionDependency) do() {}
+
 type InjectionService struct {
 	Source *InjectionDependency `inject-as:"source"`
 	Target *InjectionDependency `inject:"source"`
 }
 
 func TestField_Inject(t *testing.T) {
-	var s InjectionService
-	root, err := walk(reflect.ValueOf(&s), reflect.StructField{}, nil)
-	if err != nil {
-		t.Fatalf("walking service: %s", err)
-	}
+	// nominal cases
+	t.Run("struct pointer", func(t *testing.T) {
+		s := InjectionService{
+			Source: &InjectionDependency{
+				F: "Foo",
+			},
+		}
+		root, err := walk(reflect.ValueOf(&s), reflect.StructField{}, nil)
+		if err != nil {
+			t.Fatalf("walking service: %s", err)
+		}
 
-	if len(root.Children) != 2 {
-		t.Fatalf("unexpected number of children: wanted %d, got %d", 2, len(root.Children))
-	}
+		if len(root.Children) != 2 {
+			t.Fatalf("unexpected number of children: wanted %d, got %d", 2, len(root.Children))
+		}
 
-	err = root.Children[1].Inject(root.Children[0])
-	if err != nil {
-		t.Fatalf("unable to inject source into target: %s", err)
-	}
+		err = root.Children[1].Inject(root.Children[0])
+		if err != nil {
+			t.Fatalf("unable to inject source into target: %s", err)
+		}
 
-	if s.Source != s.Target {
-		t.Fatalf("failed injection")
+		if s.Source != s.Target {
+			t.Fatalf("failed injection")
+		}
+	})
+
+	t.Run("scalar pointer", func(t *testing.T) {
+		var s struct {
+			Source *string `inject-as:"source"`
+			Target *string `inject:"source"`
+		}
+		root, err := walk(reflect.ValueOf(&s), reflect.StructField{}, nil)
+		if err != nil {
+			t.Fatalf("walking service: %s", err)
+		}
+
+		if len(root.Children) != 2 {
+			t.Fatalf("unexpected number of children: wanted %d, got %d", 2, len(root.Children))
+		}
+
+		err = root.Children[1].Inject(root.Children[0])
+		if err != nil {
+			t.Fatalf("unable to inject source into target: %s", err)
+		}
+
+		if s.Source != s.Target {
+			t.Fatalf("failed injection")
+		}
+	})
+
+	t.Run("interface", func(t *testing.T) {
+		type doer interface {
+			do()
+		}
+
+		s := struct {
+			Source *InjectionDependency `inject-as:"source"`
+			Target doer                 `inject:"source"`
+		}{
+			Source: &InjectionDependency{
+				F: "Foo",
+			},
+		}
+		root, err := walk(reflect.ValueOf(&s), reflect.StructField{}, nil)
+		if err != nil {
+			t.Fatalf("walking service: %s", err)
+		}
+
+		if len(root.Children) != 2 {
+			t.Fatalf("unexpected number of children: wanted %d, got %d", 2, len(root.Children))
+		}
+
+		err = root.Children[1].Inject(root.Children[0])
+		if err != nil {
+			t.Fatalf("unable to inject source into target: %s", err)
+		}
+
+		if s.Source != s.Target {
+			t.Fatalf("failed injection")
+		}
+	})
+
+	// errors
+	for name, tCase := range map[string]reflect.Value{
+		"pointer into value": reflect.ValueOf(new(struct {
+			Source *InjectionDependency `inject-as:"source"`
+			Target InjectionDependency  `inject:"source"`
+		})),
+		"value into pointer": reflect.ValueOf(new(struct {
+			Source int  `inject-as:"source"`
+			Target *int `inject:"source"`
+		})),
+		"type mismatch": reflect.ValueOf(new(struct {
+			Source int    `inject-as:"source"`
+			Target string `inject:"source"`
+		})),
+	} {
+		t.Run(name, func(t *testing.T) {
+			root, err := walk(tCase, reflect.StructField{}, nil)
+			if err != nil {
+				t.Fatalf("walking service: %s", err)
+			}
+
+			if len(root.Children) != 2 {
+				t.Fatalf("unexpected number of children: wanted %d, got %d", 2, len(root.Children))
+			}
+
+			err = root.Children[0].Inject(root.Children[1])
+			if err == nil {
+				t.Fatal("expected an error, got nil")
+			}
+		})
 	}
 }

--- a/processor.go
+++ b/processor.go
@@ -190,6 +190,10 @@ func resolve(root *Field) (fields []*Field, err error) {
 		paths[e.Path] = e
 
 		if key, ok := e.Tags.Lookup(TagInjectAs); ok {
+			if e.Value.Kind() != reflect.Ptr {
+				return nil, fmt.Errorf("cannot inject non pointer type %s, defined at path %s", e.Value.Type().Name(), e.Path)
+			}
+
 			if s, ok := sources[key]; ok {
 				return nil, fmt.Errorf("injection source key %s already defined at path %s", key, s.Path)
 			}

--- a/zconfig_test.go
+++ b/zconfig_test.go
@@ -16,8 +16,8 @@ type S struct {
 	babar string
 	Bar   string
 	EE    EE `key:"ee"`
-	A     A  `key:"a" inject-as:"a"`
-	L     A  `inject:"a"`
+	A     *A `key:"a" inject-as:"a"`
+	L     *A `inject:"a"`
 	M     M  `key:"m"`
 }
 


### PR DESCRIPTION
Injection does not work when the source is a non pointer type, because values are only set after the injection phase happens. By returning an error, we can avoid surprising and possibly unexpected behaviour at runtime.